### PR TITLE
Add research interest bullet list to skills panel

### DIFF
--- a/_data/skills-languages.yml
+++ b/_data/skills-languages.yml
@@ -5,23 +5,14 @@
 # - name: Language
 #   weight: 5
 
-#- name: Generative Models
-  #weight: 4
-
-#- name: Normalizing Flows
-  #weight: 4
-
-#- name: Equivariant Networks
-  #weight: 4
-
-#- name: Adversarial Attacks
-  #weight: 4
-
-#- name: Graph Neural Networks
-  #weight: 2
-
-#- name: KG Embeddings
-  #weight: 2
-
-#- name: NLP
-  #weight: 2
+- name: Sampling from Unnormalized Densities
+- name: Boltzmann Generators
+- name: Generative models such as Diffusion and Flow Matching
+- name: Discrete Generative models, e.g., Discrete Diffusion
+- name: Molecular Dynamics
+- name: Neural Net Potentials
+- name: Protein design with generative models
+- name: Adversarial machine learning for generative models
+- name: Red teaming LLMs and Discrete Diffusion
+- name: Deep Learning theory for synthetic data
+- name: Posterior sampling and Bayesian Inference

--- a/_includes/section-skills.html
+++ b/_includes/section-skills.html
@@ -10,11 +10,15 @@
   <input type="radio" id="prospective" name="filter" />
   <label class="filter-button neumorphism-button" for="prospective">{{ site.prospective_students_title }}</label>
 
-  {% for language in site.data.skills-languages %}
-    <div skill-type="research" skill-weight="{{language.weight}}" data-aos="zoom-in">
-      {{language.name}}
+  {% if site.data.skills-languages %}
+    <div skill-type="research" data-aos="zoom-in">
+      <ul class="research-interests-list">
+        {% for language in site.data.skills-languages %}
+          <li>{{ language.name }}</li>
+        {% endfor %}
+      </ul>
     </div>
-  {% endfor %}
+  {% endif %}
   {% for student in site.data.skills-students %}
     <div skill-type="students" skill-weight="{{student.weight}}" data-aos="zoom-in">
       {% if student.url %}

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -406,6 +406,18 @@ a {
 
   div[skill-type="research"] {
     color: #e84a5f;
+
+    ul.research-interests-list {
+      margin: 0;
+      padding-left: 1.5rem;
+      list-style: disc;
+    }
+
+    ul.research-interests-list li {
+      margin-bottom: 0.5rem;
+      font-size: 1rem;
+      line-height: 1.5rem;
+    }
   }
   div[skill-type="students"] {
     color: #8d9db6;


### PR DESCRIPTION
## Summary
- populate the research interests data set with the requested topics
- render the research tab as a bulleted list and add styles so it matches the panel design

## Testing
- bundle _2.6.7_ install *(fails: nokogiri native extension build error)*

------
https://chatgpt.com/codex/tasks/task_e_68d71ba0b6048332a30cc0ec993a908b